### PR TITLE
Declare ParseType/BuildTypes as covariant/contravariant, respectively

### DIFF
--- a/construct-stubs/core.pyi
+++ b/construct-stubs/core.pyi
@@ -547,7 +547,7 @@ class Rebuild(Subconstruct[SubconParsedType, SubconBuildTypes, ParsedType, Build
         func: ConstantOrContextLambda[SubconBuildTypes],
     ) -> Rebuild[SubconParsedType, SubconBuildTypes, SubconParsedType, None]: ...
 
-class Default(Subconstruct[SubconParsedType, SubconBuildTypes, ParsedType, BuildTypes]):
+class Default(Subconstruct[SubconParsedType, SubconBuildTypes, SubconParsedType, t.Optional[SubconBuildTypes]]):
     value: ConstantOrContextLambda2[SubconBuildTypes]
     def __new__(
         cls,

--- a/construct-stubs/core.pyi
+++ b/construct-stubs/core.pyi
@@ -85,8 +85,8 @@ def stream_iseof(stream: t.BinaryIO) -> bool: ...
 # ===============================================================================
 # abstract constructs
 # ===============================================================================
-ParsedType = t.TypeVar("ParsedType")
-BuildTypes = t.TypeVar("BuildTypes")
+ParsedType = t.TypeVar("ParsedType", covariant=True)
+BuildTypes = t.TypeVar("BuildTypes", contravariant=True)
 
 class Construct(t.Generic[ParsedType, BuildTypes]):
     name: t.Optional[str]

--- a/construct_typed/tunion.py
+++ b/construct_typed/tunion.py
@@ -28,9 +28,9 @@ def TUnionField(
         # some subcons have a predefined default value. all other have "None"
         default: t.Any = None
         if isinstance(subcon, (cs.Const, cs.Default)):
-            if callable(subcon.value):  # type: ignore
+            if callable(subcon.value):
                 raise ValueError("lamda as default is not supported")
-            default = subcon.value  # type: ignore
+            default = subcon.value
 
         # if subcon builds from "None", set default to "None"
         field = dataclasses.field(


### PR DESCRIPTION
This allows for passing Constructs with subclass/superclass `ParseType`/`BuildTypes` to Subconstructs, as would be expected.

The covariance test is admittedly not a great example; my actual reason is for this is to have correctly typed arguments in a `TStruct`, but that wouldn't belong in the core tests:

```py
@dataclass
class Whatever(cst.TContainerBase):
    misc: list[int] = cst.TStructField(cs.Byte[4])
```