### PR TITLE
Bump construct-typing to 2.10.70 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="Tim Riddermann",
     python_requires=">=3.7",
     install_requires=[
-        "construct==2.10.68",
+        "construct==2.10.70",
         "typing_extensions>=4.6.0"
     ],
     keywords=[


### PR DESCRIPTION
`construct` has had a few releases since the last update of this project, it would be nice to look into this further