### PR TITLE
Optimize type stubs for `Computed`, `Default` and `Rebuild` in conjunction with `ty`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Bumped minimum required Python version to 3.10 (previously: 3.9 which has reached end-of-life).
 - Removed `version.py`, use `importlib.metadata` instead to get the version number.
 - Use `uv` as a project management tool and `poe` as a task runner.
+- Optimize type stubs for `Computed`, `Default` and `Rebuild` in conjunction with `ty`.

--- a/construct-stubs/core.pyi
+++ b/construct-stubs/core.pyi
@@ -496,7 +496,7 @@ class Sequence(Construct[ListContainer[t.Any], t.Optional[t.List[t.Any]]]):
 # arrays ranges and repeaters
 # ===============================================================================
 class Array(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         ListContainer[SubconParsedType],  # type: ignore
@@ -513,7 +513,7 @@ class Array(
     ) -> None: ...
 
 class GreedyRange(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         ListContainer[SubconParsedType],  # type: ignore
@@ -528,7 +528,7 @@ class GreedyRange(
     ) -> None: ...
 
 class RepeatUntil(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         ListContainer[SubconParsedType],  # type: ignore
@@ -951,7 +951,7 @@ class RawCopyObj(t.Generic[ParsedType], Container[t.Any]):
     length: int
 
 class RawCopy(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         RawCopyObj[SubconParsedType],
@@ -1162,7 +1162,7 @@ class EncryptedSymAead(Tunnel[SubconParsedType, SubconBuildTypes]):
 # lazy equivalents
 # ===============================================================================
 class Lazy(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         t.Callable[[], SubconParsedType],
@@ -1195,7 +1195,7 @@ class LazyStruct(Construct[LazyContainer[t.Any], t.Optional[t.Dict[str, t.Any]]]
 class LazyListContainer(t.List[ListType]): ...
 
 class LazyArray(
-    Subconstruct[
+    Subconstruct[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         ListContainer[SubconParsedType],  # type: ignore
@@ -1259,7 +1259,7 @@ def Filter(
 ]: ...
 
 class Slicing(
-    Adapter[
+    Adapter[  # ty: ignore[invalid-generic-class]
         SubconParsedType,
         SubconBuildTypes,
         ListContainer[SubconParsedType],  # type: ignore

--- a/construct-stubs/core.pyi
+++ b/construct-stubs/core.pyi
@@ -585,9 +585,15 @@ class Const(Subconstruct[t.Any, t.Any, ParsedType, BuildTypes]):
 
 class Computed(Construct[ParsedType, None]):
     func: ConstantOrContextLambda2[ParsedType]
+    @t.overload
     def __init__(
         self,
-        func: ConstantOrContextLambda2[ParsedType],
+        func: t.Callable[[Context], ParsedType],
+    ) -> None: ...
+    @t.overload
+    def __init__(
+        self,
+        func: ParsedType,
     ) -> None: ...
 
 Index: Construct[int, t.Any]

--- a/construct-stubs/core.pyi
+++ b/construct-stubs/core.pyi
@@ -593,11 +593,18 @@ class Computed(Construct[ParsedType, None]):
 Index: Construct[int, t.Any]
 
 class Rebuild(Subconstruct[SubconParsedType, SubconBuildTypes, SubconParsedType, None]):
-    func: ConstantOrContextLambda[SubconBuildTypes]
+    func: ConstantOrContextLambda2[SubconBuildTypes]
+    @t.overload
     def __init__(
         self,
         subcon: Construct[SubconParsedType, SubconBuildTypes],
-        func: ConstantOrContextLambda[SubconBuildTypes],
+        func: SubconBuildTypes,
+    ) -> None: ...
+    @t.overload
+    def __init__(
+        self,
+        subcon: Construct[SubconParsedType, SubconBuildTypes],
+        func: t.Callable[[Context], SubconBuildTypes],
     ) -> None: ...
 
 class Default(
@@ -608,11 +615,18 @@ class Default(
         t.Optional[SubconBuildTypes],
     ]
 ):
-    value: ConstantOrContextLambda[SubconBuildTypes]
+    value: ConstantOrContextLambda2[SubconBuildTypes]
+    @t.overload
     def __init__(
         self,
         subcon: Construct[SubconParsedType, SubconBuildTypes],
-        value: ConstantOrContextLambda[SubconBuildTypes],
+        value: SubconBuildTypes,
+    ) -> None: ...
+    @t.overload
+    def __init__(
+        self,
+        subcon: Construct[SubconParsedType, SubconBuildTypes],
+        value: t.Callable[[Context], SubconBuildTypes],
     ) -> None: ...
 
 class Check(Construct[None, None]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ exclude = [
 # These warnings should be activated as "error" in the future, but for now we don't want to refactor the entire codebase right now.
 # Valid values: "error", "warn", "ignore"
 [tool.ty.rules]
-invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-generic-class = "ignore"
 invalid-legacy-type-variable = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,12 +131,7 @@ exclude = [
     "libs",
 ]
 
-# These warnings should be activated as "error" in the future, but for now we don't want to refactor the entire codebase right now.
-# Valid values: "error", "warn", "ignore"
 [tool.ty.rules]
-invalid-assignment = "ignore"
-invalid-legacy-type-variable = "ignore"
-invalid-type-arguments = "ignore"
 unused-type-ignore-comment = "ignore"
 
 [tool.ty.terminal]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ exclude = [
 # Valid values: "error", "warn", "ignore"
 [tool.ty.rules]
 invalid-assignment = "ignore"
-invalid-generic-class = "ignore"
 invalid-legacy-type-variable = "ignore"
 invalid-type-arguments = "ignore"
 unused-type-ignore-comment = "ignore"

--- a/tests/declarativeunittest.py
+++ b/tests/declarativeunittest.py
@@ -3,9 +3,19 @@ import io
 import typing as t
 
 import pytest
-from construct import *
-from construct.lib import *
-
+from construct import (
+    Construct,
+    ListContainer,
+    Container,
+    HexDisplayedBytes,
+    HexDisplayedDict,
+    HexDisplayedInteger,
+    HexDumpDisplayedBytes,
+    HexDumpDisplayedDict,
+    EnumInteger,
+    EnumIntegerString,
+    SizeofError,
+)
 import construct_typed as cst
 
 xfail = pytest.mark.xfail
@@ -39,9 +49,7 @@ def ident(x: IdentType) -> IdentType:
 devzero: t.BinaryIO = ZeroIO()  # type: ignore
 
 
-def raises(
-    func: t.Callable[..., t.Any], *args: t.Any, **kw: t.Any
-) -> t.Union[t.Any, Exception]:
+def raises(func: t.Callable[..., t.Any], *args: t.Any, **kw: t.Any) -> t.Union[t.Any, Exception]:
     try:
         return func(*args, **kw)
     except Exception as e:
@@ -54,9 +62,8 @@ def common(
     datasample: Buffer,
     objsample: t.Union[ContainerType, t.Dict[str, t.Any]],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -65,9 +72,8 @@ def common(
     datasample: Buffer,
     objsample: t.List[ParsedType],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -76,9 +82,8 @@ def common(
     datasample: Buffer,
     objsample: t.Dict[str, t.Any],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -87,9 +92,8 @@ def common(
     datasample: Buffer,
     objsample: t.Union[int, str],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -98,9 +102,8 @@ def common(
     datasample: Buffer,
     objsample: t.Union[HexDisplayedInteger, int],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -109,9 +112,8 @@ def common(
     datasample: Buffer,
     objsample: t.Union[HexDisplayedBytes, bytes],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -120,9 +122,8 @@ def common(
     datasample: Buffer,
     objsample: t.Dict[str, t.Any],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -131,9 +132,8 @@ def common(
     datasample: Buffer,
     objsample: t.Union[HexDumpDisplayedBytes, bytes],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -142,9 +142,8 @@ def common(
     datasample: Buffer,
     objsample: t.Dict[str, t.Any],
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 @t.overload
@@ -153,9 +152,8 @@ def common(
     datasample: Buffer,
     objsample: ParsedType,
     sizesample: t.Union[int, t.Type[Exception]] = ...,
-    **kw: t.Any
-) -> None:
-    ...
+    **kw: t.Any,
+) -> None: ...
 
 
 def common(
@@ -163,7 +161,7 @@ def common(
     datasample: Buffer,
     objsample: t.Any,
     sizesample: t.Union[int, t.Type[Exception]] = SizeofError,
-    **kw: t.Any
+    **kw: t.Any,
 ) -> None:
     obj = format.parse(datasample, **kw)
     assert obj == objsample

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -562,6 +562,12 @@ def test_rebuild() -> None:
     assert d.build(dict(count=-1,items=[255])) == b"\x01\xff"
     assert d.build(dict(items=[255])) == b"\x01\xff"
 
+def test_rebuild_lambda() -> None:
+    """Lambdas in a `Rebuild` are working and check that `ty` dont throw an `invalid-argument-type` error."""
+    r_lambda = Rebuild(Bytes(4), lambda ctx: b"TEST")
+    assert r_lambda.build(None) == b"TEST"
+    assert r_lambda.parse(b"TEST") == b"TEST"
+
 def test_rebuild_issue_664() -> None:
     d = Struct(
         "bytes" / Bytes(1),
@@ -612,6 +618,12 @@ def test_default() -> None:
     d = Default(Byte, 0)
     common(d, b"\xff", 255, 1)
     assert d.build(None) == b"\x00"
+
+def test_default_lambda() -> None:
+    """Lambdas in a `Default` are working and check that `ty` dont throw an `invalid-argument-type` error."""
+    d_lambda = Default(Bytes(4), lambda ctx: b"TEST")
+    assert d_lambda.build(None) == b"TEST"
+    assert d_lambda.parse(b"TEST") == b"TEST"
 
 def test_check() -> None:
     common(Check(True), b"", None, 0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -537,6 +537,12 @@ def test_computed() -> None:
     assert raises(Computed(this.missing).parse, b"") == KeyError
     assert raises(Computed(this["missing"]).parse, b"") == KeyError
 
+def test_computed_lambda() -> None:
+    """Lambdas in a `Computed` are working and check that `ty` dont throw an `invalid-argument-type` error."""
+    c_lambda: "Computed[int]" = Computed(lambda ctx: 50)
+    assert c_lambda.build(None) == b""
+    assert c_lambda.parse(b"") == 50
+
 def test_index() -> None:
     d1 = Array(3, Bytes(this._index+1))
     common(d1, b"abbccc", [b"a", b"bb", b"ccc"])


### PR DESCRIPTION
- Optimize type stubs for `Computed`, `Default` and `Rebuild` in conjunction with `ty`.
- Enable more previously disabled `ty` rules